### PR TITLE
Do not dispose returned streams

### DIFF
--- a/itext.pdfimage/PdfToImageConverter.cs
+++ b/itext.pdfimage/PdfToImageConverter.cs
@@ -38,11 +38,9 @@ namespace itext.pdfimage
         {
             foreach (var bmp in ConvertToBitmaps(pdfDocument))
             {
-                using (var ms = new MemoryStream())
-                {
-                    bmp.Save(ms, ImageFormat.Jpeg);
-                    yield return ms;
-                }
+                var ms = new MemoryStream()
+                bmp.Save(ms, ImageFormat.Jpeg);
+                yield return ms;
                 bmp.Dispose();
             }
         }
@@ -127,12 +125,10 @@ namespace itext.pdfimage
         public Stream ConvertToJpgStream(PdfPage pdfPage)
         {
             var bmp = ConvertToBitmap(pdfPage);
-            using (var ms = new MemoryStream())
-            {
-                bmp.Save(ms, ImageFormat.Jpeg);
-                bmp.Dispose();
-                return ms;
-            }
+            var ms = new MemoryStream();
+            bmp.Save(ms, ImageFormat.Jpeg);
+            bmp.Dispose();
+            return ms;
         }
 
         private Func<float> IncreaseCounter = () => counter = Interlocked.Increment(ref counter);


### PR DESCRIPTION
When returning or yielding a Stream it is important not to dispose it (by putting it in a using block or otherwise), because if you do, the caller of your function won't be able to use it. The caller should be responsible for ensuring the stream is properly disposed.

As a side note, I'm pretty sure a MemoryStream doesn't actually do anything useful when you call Dispose() on it, other than maybe removing the reference to its backing array.